### PR TITLE
GUI: Open web links in default browser

### DIFF
--- a/src/gui_link.cpp
+++ b/src/gui_link.cpp
@@ -116,7 +116,7 @@ LRESULT CALLBACK GuiCtrlHyperlink::WndProc(HWND hwnd,UINT message,WPARAM wParam,
 
 void GuiCtrlHyperlink::goto_link(int i)
 {
-  ShellExecute(NULL,"open","iexplore",work.link[i].c_str(),NULL,SW_SHOWDEFAULT);
+  ShellExecute(NULL,"open",work.link[i].c_str(),NULL,NULL,SW_SHOWDEFAULT);
 }
 
 bool GuiCtrlHyperlink::is_warm(int i)


### PR DESCRIPTION
AdPlug about box opens web hyperlinks in IE browser, even if another default system browser is set.

Fixed.